### PR TITLE
fix: update path mappings in tsconfig for client and server

### DIFF
--- a/apps/client/tsconfig.json
+++ b/apps/client/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "dist",
     "paths": {
-      "@client/*": ["src/*"]
+      "@client/*": ["apps/client/src/*"]
     },
     "plugins": [
       {

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "dist",
     "paths": {
-      "@server/*": ["src/*"]
+      "@server/*": ["apps/server/src/*"]
     }
   },
   "include": ["src"],


### PR DESCRIPTION
This pull request updates the `tsconfig.json` files for both the client and server applications to ensure proper resolution of module paths. The changes adjust the `paths` configuration to reflect the correct directory structure.

Updates to `tsconfig.json` files:

* [`apps/client/tsconfig.json`](diffhunk://#diff-fd06260f2867a2147e72af339572e78b75f46d8930e1166a9616559e264751f7L6-R6): Updated the `@client/*` path mapping to point to `apps/client/src/*` instead of `src/*`.
* [`apps/server/tsconfig.json`](diffhunk://#diff-2d95446251cb0efc3452d1fa51b9848f788b6b7c9a0122f01d34c901b61c21cfL6-R6): Updated the `@server/*` path mapping to point to `apps/server/src/*` instead of `src/*`.