### PR TITLE
Feature/fetch layout info

### DIFF
--- a/apps/client/src/api/openapi/requests/types.gen.ts
+++ b/apps/client/src/api/openapi/requests/types.gen.ts
@@ -23,6 +23,7 @@ export type PostAuthRegisterResponse = {
     birthDate: string;
     role: 'admin' | 'user';
     profileImage: string;
+    layout: 'list' | 'grid';
     storageSpaceInMB: string;
     usedStorageInBytes: string;
 };
@@ -46,6 +47,7 @@ export type PostAuthLoginResponse = {
     birthDate: string;
     role: 'admin' | 'user';
     profileImage: string;
+    layout: 'list' | 'grid';
     storageSpaceInMB: string;
     usedStorageInBytes: string;
 };
@@ -97,6 +99,7 @@ export type PostAuthGoogleResponse = {
     birthDate: string;
     role: 'admin' | 'user';
     profileImage: string;
+    layout: 'list' | 'grid';
     storageSpaceInMB: string;
     usedStorageInBytes: string;
 };
@@ -110,6 +113,7 @@ export type GetAccountMeResponse = {
     birthDate: string;
     role: 'admin' | 'user';
     profileImage: string;
+    layout: 'list' | 'grid';
     storageSpaceInMB: string;
     usedStorageInBytes: string;
 };
@@ -131,6 +135,7 @@ export type $OpenApiTs = {
                     birthDate: string;
                     role: 'admin' | 'user';
                     profileImage: string;
+                    layout: 'list' | 'grid';
                     storageSpaceInMB: string;
                     usedStorageInBytes: string;
                 };
@@ -633,6 +638,7 @@ export type $OpenApiTs = {
                     birthDate: string;
                     role: 'admin' | 'user';
                     profileImage: string;
+                    layout: 'list' | 'grid';
                     storageSpaceInMB: string;
                     usedStorageInBytes: string;
                 };
@@ -2123,6 +2129,7 @@ export type $OpenApiTs = {
                     birthDate: string;
                     role: 'admin' | 'user';
                     profileImage: string;
+                    layout: 'list' | 'grid';
                     storageSpaceInMB: string;
                     usedStorageInBytes: string;
                 };
@@ -2624,6 +2631,7 @@ export type $OpenApiTs = {
                     birthDate: string;
                     role: 'admin' | 'user';
                     profileImage: string;
+                    layout: 'list' | 'grid';
                     storageSpaceInMB: string;
                     usedStorageInBytes: string;
                 };

--- a/apps/client/src/app/[lng]/(main)/components/DashboardHeader/DashboardHeader.tsx
+++ b/apps/client/src/app/[lng]/(main)/components/DashboardHeader/DashboardHeader.tsx
@@ -6,11 +6,12 @@ import { useTranslation } from 'react-i18next';
 import { Button, Dropdown, SegmentedControl } from '@client/components';
 import { faList, faTableCellsLarge, faUpload } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import Skeleton, { SkeletonTheme } from 'react-loading-skeleton';
 
 interface Props {
   parents?: string[];
   title: string;
-  layout: 'grid' | 'list';
+  layout: 'grid' | 'list' | null;
   onChangeLayout: (value: string) => void;
 }
 
@@ -51,15 +52,21 @@ export const DashboardHeader = ({ parents, title, layout, onChangeLayout }: Prop
           placeholder={t('common.sort.sortBy')}
         />
 
-        <SegmentedControl
-          options={[
-            { value: 'grid', icon: <FontAwesomeIcon icon={faTableCellsLarge} /> },
-            { value: 'list', icon: <FontAwesomeIcon icon={faList} /> }
-          ]}
-          value={layout}
-          onChange={(value) => onChangeLayout(value)}
-          size="sm"
-        />
+        {layout ? (
+          <SegmentedControl
+            options={[
+              { value: 'grid', icon: <FontAwesomeIcon icon={faTableCellsLarge} /> },
+              { value: 'list', icon: <FontAwesomeIcon icon={faList} /> }
+            ]}
+            value={layout}
+            onChange={(value) => onChangeLayout(value)}
+            size="sm"
+          />
+        ) : (
+          <SkeletonTheme baseColor="var(--bg-color)" highlightColor="var(--secondary-bg-color)">
+            <Skeleton count={1} height={32} width={110} />
+          </SkeletonTheme>
+        )}
 
         <Button size="sm" icon={<FontAwesomeIcon icon={faUpload} />}>
           {t('common.upload')}

--- a/apps/client/src/app/[lng]/(main)/components/DashboardHeader/DashboardHeader.tsx
+++ b/apps/client/src/app/[lng]/(main)/components/DashboardHeader/DashboardHeader.tsx
@@ -51,6 +51,7 @@ export const DashboardHeader = ({ parents, title, layout, onChangeLayout }: Prop
           size="sm"
           placeholder={t('common.sort.sortBy')}
         />
+        {/* TODO: add sort functionality */}
 
         {layout ? (
           <SegmentedControl
@@ -62,6 +63,7 @@ export const DashboardHeader = ({ parents, title, layout, onChangeLayout }: Prop
             onChange={(value) => onChangeLayout(value)}
             size="sm"
           />
+          // TODO: add layout change functionality
         ) : (
           <SkeletonTheme baseColor="var(--bg-color)" highlightColor="var(--secondary-bg-color)">
             <Skeleton count={1} height={32} width={110} />

--- a/apps/client/src/app/[lng]/(main)/dashboard/page.tsx
+++ b/apps/client/src/app/[lng]/(main)/dashboard/page.tsx
@@ -2,14 +2,20 @@
 
 import { DashboardHeader } from '@client/app/[lng]/(main)/components';
 import { ItemGrid } from '@client/components';
+import { useAuth } from '@client/hooks';
 import { iconsMap } from '@client/utils';
 import { faEllipsis } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import Skeleton, { SkeletonTheme } from 'react-loading-skeleton';
 
 const Page = () => {
-  const [layout, setLayout] = useState<'grid' | 'list'>('grid');
-  // TODO : fetch layout from user preferences or default to 'grid'
+  const { user } = useAuth();
+  const [layout, setLayout] = useState<'grid' | 'list' | null>(user?.layout || null);
+
+  useEffect(() => {
+    if (user?.layout) setLayout(user.layout);
+  }, [user?.layout]);
 
   const onChangeLayout = (value: string) => {
     switch (value) {
@@ -24,15 +30,16 @@ const Page = () => {
     }
   };
 
-  return (
-    <>
-      <DashboardHeader title="Dashboard" layout={layout} onChangeLayout={onChangeLayout} />
-      <div className="pt-4">
-        {layout === 'grid' ? (
+  const renderLayout = () => {
+    switch (layout) {
+      case 'grid':
+        return (
           <div className="grid-auto-fill-200 gap-6">
             <ItemGrid link="#" title="Projects" description="4 items" icon="folder" />
           </div>
-        ) : (
+        );
+      case 'list':
+        return (
           <div>
             <div className="font-bold text-(--text-secondary) grid-5-cols gap-4 px-4 py-3 rounded-2xl border-b-1 border-(--border-color)">
               <span>Name</span>
@@ -48,10 +55,26 @@ const Page = () => {
               <span className="text-ellipsis overflow-hidden">Action Movie.mp4</span>
               <span className="text-ellipsis overflow-hidden">Action Movie.mp4</span>
               <span className="text-ellipsis overflow-hidden">Action Movie.mp4</span>
-              <span className="text-ellipsis overflow-hidden"><FontAwesomeIcon icon={faEllipsis} /></span>
+              <span className="text-ellipsis overflow-hidden">
+                <FontAwesomeIcon icon={faEllipsis} />
+              </span>
             </div>
           </div>
-        )}
+        );
+      default:
+        return (
+          <SkeletonTheme baseColor="var(--bg-color)" highlightColor="var(--secondary-bg-color)">
+            <Skeleton count={3} height="200px" width="100%" />
+          </SkeletonTheme>
+        );
+    }
+  };
+
+  return (
+    <>
+      <DashboardHeader title="Dashboard" layout={layout} onChangeLayout={onChangeLayout} />
+      <div className="pt-4">
+        {renderLayout()}
       </div>
     </>
   );

--- a/apps/server/src/models/user.ts
+++ b/apps/server/src/models/user.ts
@@ -32,7 +32,8 @@ export const profileSchema = userSchema
     role: true
   })
   .extend({
-    profileImage: z.string().base64()
+    profileImage: z.string().base64(),
+    layout: z.nativeEnum($Enums.layoutEnum)
   })
   .merge(
     storageSchema.pick({

--- a/apps/server/src/routes/account.ts
+++ b/apps/server/src/routes/account.ts
@@ -23,7 +23,7 @@ router.get('/me', authenticateWithCookie, async (req: AuthenticatedRequest, res)
       role: req.user!.role,
       sex: req.user!.sex,
       birthDate: req.user!.birthDate,
-      layout: foundGeneralPreferences!.layout,
+      layout: foundGeneralPreferences?.layout || 'grid',
       profileImage: await getProfileImageInBase64(req.user!.username, foundUser!.profileImage)
     };
 

--- a/apps/server/src/routes/account.ts
+++ b/apps/server/src/routes/account.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 
-import { getUserByEmail } from '@server/db';
+import { getGeneralPreferenceByUserId, getUserByEmail } from '@server/db';
 import { AuthenticatedRequest, Profile } from '@server/models';
 import { authenticateWithCookie, getProfileImageInBase64 } from '@server/utils';
 import { ErrorCodes } from '@shared/types';
@@ -10,6 +10,8 @@ const router = express.Router();
 router.get('/me', authenticateWithCookie, async (req: AuthenticatedRequest, res) => {
   try {
     const foundUser = await getUserByEmail(req.user!.email);
+    
+    const foundGeneralPreferences = await getGeneralPreferenceByUserId(foundUser!.id);
 
     const response: Profile = {
       email: req.user!.email,
@@ -21,6 +23,7 @@ router.get('/me', authenticateWithCookie, async (req: AuthenticatedRequest, res)
       role: req.user!.role,
       sex: req.user!.sex,
       birthDate: req.user!.birthDate,
+      layout: foundGeneralPreferences!.layout,
       profileImage: await getProfileImageInBase64(req.user!.username, foundUser!.profileImage)
     };
 

--- a/apps/server/src/routes/auth.ts
+++ b/apps/server/src/routes/auth.ts
@@ -10,6 +10,7 @@ import { $Enums } from '@prisma/client';
 import {
   createSession,
   createUserAndStorageAndPreferences,
+  getGeneralPreferenceByUserId,
   getStorageInfoByUserId,
   getUserByEmail,
   updateGeneralPreferenceByUserId,
@@ -146,6 +147,8 @@ router.post('/register', async (req, res) => {
       banDurationMinutes: null
     });
 
+    const preferences = await getGeneralPreferenceByUserId(createdUser.id);
+
     const response: Profile = {
       email: createdUser.email,
       username: createdUser.username,
@@ -154,6 +157,7 @@ router.post('/register', async (req, res) => {
       role: createdUser.role,
       sex: createdUser.sex,
       birthDate: createdUser.birthDate,
+      layout: preferences!.layout,
       storageSpaceInMB: String(DEFAULT_STORAGE_SPACE_IN_MB),
       usedStorageInBytes: String(DEFAULT_USED_STORAGE_SPACE),
       profileImage: await getProfileImageInBase64(createdUser.username, profileImageName)
@@ -299,6 +303,8 @@ router.post('/login', async (req, res) => {
 
     await updateGeneralPreferenceByUserId(foundUser.id, { language });
 
+    const preferences = await getGeneralPreferenceByUserId(foundUser.id);
+
     const response: Profile = {
       email: foundUser.email,
       username: foundUser.username,
@@ -307,6 +313,7 @@ router.post('/login', async (req, res) => {
       role: foundUser.role,
       sex: foundUser.sex,
       birthDate: foundUser.birthDate,
+      layout: preferences!.layout,
       storageSpaceInMB: String(foundStorage.storageSpaceInMB),
       usedStorageInBytes: String(foundStorage.usedStorageInBytes),
       profileImage: await getProfileImageInBase64(foundUser.username, foundUser.profileImage)
@@ -630,6 +637,8 @@ router.post('/google', async (req, res) => {
       });
     }
 
+    const preferences = await getGeneralPreferenceByUserId(foundUser.id);
+
     const response: Profile = {
       email: foundUser.email,
       username: foundUser.username,
@@ -638,6 +647,7 @@ router.post('/google', async (req, res) => {
       role: foundUser.role,
       sex: foundUser.sex,
       birthDate: foundUser.birthDate,
+      layout: preferences!.layout,
       storageSpaceInMB: String(storageInfo?.storageSpaceInMB || DEFAULT_STORAGE_SPACE_IN_MB),
       usedStorageInBytes: String(storageInfo?.usedStorageInBytes || DEFAULT_USED_STORAGE_SPACE),
       profileImage: await getProfileImageInBase64(foundUser.username, foundUser.profileImage)

--- a/apps/server/src/routes/auth.ts
+++ b/apps/server/src/routes/auth.ts
@@ -157,7 +157,7 @@ router.post('/register', async (req, res) => {
       role: createdUser.role,
       sex: createdUser.sex,
       birthDate: createdUser.birthDate,
-      layout: preferences!.layout,
+      layout: preferences?.layout || 'grid',
       storageSpaceInMB: String(DEFAULT_STORAGE_SPACE_IN_MB),
       usedStorageInBytes: String(DEFAULT_USED_STORAGE_SPACE),
       profileImage: await getProfileImageInBase64(createdUser.username, profileImageName)
@@ -313,7 +313,7 @@ router.post('/login', async (req, res) => {
       role: foundUser.role,
       sex: foundUser.sex,
       birthDate: foundUser.birthDate,
-      layout: preferences!.layout,
+      layout: preferences?.layout || 'grid',
       storageSpaceInMB: String(foundStorage.storageSpaceInMB),
       usedStorageInBytes: String(foundStorage.usedStorageInBytes),
       profileImage: await getProfileImageInBase64(foundUser.username, foundUser.profileImage)
@@ -647,7 +647,7 @@ router.post('/google', async (req, res) => {
       role: foundUser.role,
       sex: foundUser.sex,
       birthDate: foundUser.birthDate,
-      layout: preferences!.layout,
+      layout: preferences?.layout || 'grid',
       storageSpaceInMB: String(storageInfo?.storageSpaceInMB || DEFAULT_STORAGE_SPACE_IN_MB),
       usedStorageInBytes: String(storageInfo?.usedStorageInBytes || DEFAULT_USED_STORAGE_SPACE),
       profileImage: await getProfileImageInBase64(foundUser.username, foundUser.profileImage)


### PR DESCRIPTION
This pull request introduces a new `layout` property to user profiles, allowing users to select between `list` and `grid` views. The changes span both the client and server codebases, ensuring the `layout` preference is stored, retrieved, and rendered appropriately in the UI. Key changes include updates to the API response types, server routes, and client-side components to support this new feature.

### API and Backend Updates:
* Added a new `layout` property to the `Profile` schema and API response types, with possible values of `'list'` or `'grid'`. This property is included in `PostAuthRegisterResponse`, `PostAuthLoginResponse`, `PostAuthGoogleResponse`, and `GetAccountMeResponse` in `apps/client/src/api/openapi/requests/types.gen.ts`. [[1]](diffhunk://#diff-246ec1dd188cdbccaa8843bdc6557aa403bee47ddc423fef3467e53ac5815533R26) [[2]](diffhunk://#diff-246ec1dd188cdbccaa8843bdc6557aa403bee47ddc423fef3467e53ac5815533R50) [[3]](diffhunk://#diff-246ec1dd188cdbccaa8843bdc6557aa403bee47ddc423fef3467e53ac5815533R102) [[4]](diffhunk://#diff-246ec1dd188cdbccaa8843bdc6557aa403bee47ddc423fef3467e53ac5815533R116)
* Updated server routes (`/register`, `/login`, `/google`, and `/me`) to fetch and include the `layout` preference from the database in the user profile response. [[1]](diffhunk://#diff-0749f6dc0314a9f69e17ab85c8500b5152193609e4d98f8a0e55c69462c2785cR14-R15) [[2]](diffhunk://#diff-0749f6dc0314a9f69e17ab85c8500b5152193609e4d98f8a0e55c69462c2785cR26) [[3]](diffhunk://#diff-b082374ab5980aaa1162ff2299ecb2eb193f313c270aed80dad035e137529189R150-R151) [[4]](diffhunk://#diff-b082374ab5980aaa1162ff2299ecb2eb193f313c270aed80dad035e137529189R160) [[5]](diffhunk://#diff-b082374ab5980aaa1162ff2299ecb2eb193f313c270aed80dad035e137529189R306-R307) [[6]](diffhunk://#diff-b082374ab5980aaa1162ff2299ecb2eb193f313c270aed80dad035e137529189R316) [[7]](diffhunk://#diff-b082374ab5980aaa1162ff2299ecb2eb193f313c270aed80dad035e137529189R640-R641) [[8]](diffhunk://#diff-b082374ab5980aaa1162ff2299ecb2eb193f313c270aed80dad035e137529189R650)

### Client-Side Updates:
* Modified the `DashboardHeader` component to handle a `null` layout state and display a skeleton loader when the layout is not yet determined. ([apps/client/src/app/[lng]/(main)/components/DashboardHeader/DashboardHeader.tsxR9-R14](diffhunk://#diff-f27d30d3552df174c65d61c789bb9de64a15c994f4de91b55d7a13f14ee1a625R9-R14), [apps/client/src/app/[lng]/(main)/components/DashboardHeader/DashboardHeader.tsxR55](diffhunk://#diff-f27d30d3552df174c65d61c789bb9de64a15c994f4de91b55d7a13f14ee1a625R55), [apps/client/src/app/[lng]/(main)/components/DashboardHeader/DashboardHeader.tsxR65-R69](diffhunk://#diff-f27d30d3552df174c65d61c789bb9de64a15c994f4de91b55d7a13f14ee1a625R65-R69))
* Updated the `dashboard/page.tsx` file to initialize the layout state based on the authenticated user's preferences and provide a fallback skeleton loader for the default state. ([apps/client/src/app/[lng]/(main)/dashboard/page.tsxR5-R18](diffhunk://#diff-c45f39821695a9c905c8c42b31a842517bb2f1106b02233adbfa347e3c1dc7bbR5-R18), [apps/client/src/app/[lng]/(main)/dashboard/page.tsxR33-R42](diffhunk://#diff-c45f39821695a9c905c8c42b31a842517bb2f1106b02233adbfa347e3c1dc7bbR33-R42), [apps/client/src/app/[lng]/(main)/dashboard/page.tsxL51-R77](diffhunk://#diff-c45f39821695a9c905c8c42b31a842517bb2f1106b02233adbfa347e3c1dc7bbL51-R77))

### Database and Models:
* Extended the `profileSchema` in `apps/server/src/models/user.ts` to include the `layout` property, using a native enum type for validation.

These changes collectively enhance the user experience by personalizing the dashboard layout based on user preferences and ensuring a seamless transition between states.